### PR TITLE
Добавление User-Agent и IHttpClientFactory

### DIFF
--- a/src/tabalon.ismp.crpt/csp/QRParserTest/IsmpRequestTests.cs
+++ b/src/tabalon.ismp.crpt/csp/QRParserTest/IsmpRequestTests.cs
@@ -20,7 +20,7 @@ namespace QRParserTest
         public IsmpRequestTests()
         {
             var services = new ServiceCollection();
-            services.AddTransient<HttpClient>((sp) => new HttpClient(new Mock<HttpMessageHandler>().Object)); // Mock handler per client
+            services.AddHttpClient(); // Add IHttpClientFactory
             services.AddSingleton(new IsmpClientConfig { BaseUrlTobacco = "https://test.com", BaseUrlOther = "https://test.com", HttpTimeoutInSeconds = 5 });
             services.AddLogging(); // Add logging
             _serviceProvider = services.BuildServiceProvider();
@@ -38,8 +38,12 @@ namespace QRParserTest
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"test\":\"data\"}") });
 
+            var httpClient = new HttpClient(handlerMock.Object);
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
             var services = new ServiceCollection();
-            services.AddTransient<HttpClient>((sp) => new HttpClient(handlerMock.Object));
+            services.AddSingleton(httpClientFactoryMock.Object);
             services.AddSingleton(new IsmpClientConfig { BaseUrlTobacco = "https://test.com", BaseUrlOther = "https://test.com", HttpTimeoutInSeconds = 5 });
             services.AddLogging();
             var sp = services.BuildServiceProvider();
@@ -69,8 +73,12 @@ namespace QRParserTest
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
                 .ThrowsAsync(new TaskCanceledException("Timeout"));
 
+            var httpClient = new HttpClient(handlerMock.Object);
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
             var services = new ServiceCollection();
-            services.AddTransient<HttpClient>((sp) => new HttpClient(handlerMock.Object));
+            services.AddSingleton(httpClientFactoryMock.Object);
             services.AddSingleton(new IsmpClientConfig { BaseUrlTobacco = "https://test.com", BaseUrlOther = "https://test.com", HttpTimeoutInSeconds = 5 });
             services.AddLogging();
             var sp = services.BuildServiceProvider();
@@ -94,10 +102,14 @@ namespace QRParserTest
             var handlerMock = new Mock<HttpMessageHandler>();
             handlerMock.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .Returns(() => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden) { Content = new StringContent("Forbidden") }));
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Forbidden) { Content = new StringContent("Forbidden") });
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
             var services = new ServiceCollection();
-            services.AddTransient<HttpClient>((sp) => new HttpClient(handlerMock.Object));
+            services.AddSingleton(httpClientFactoryMock.Object);
             services.AddSingleton(new IsmpClientConfig { BaseUrlTobacco = "https://test.com", BaseUrlOther = "https://test.com", HttpTimeoutInSeconds = 5 });
             services.AddLogging();
             var sp = services.BuildServiceProvider();
@@ -133,8 +145,12 @@ namespace QRParserTest
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("Success") });
                 });
 
+            var httpClient = new HttpClient(handlerMock.Object);
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
             var services = new ServiceCollection();
-            services.AddTransient<HttpClient>((sp) => new HttpClient(handlerMock.Object));
+            services.AddSingleton(httpClientFactoryMock.Object);
             services.AddSingleton(new IsmpClientConfig { BaseUrlTobacco = "https://test.com", BaseUrlOther = "https://test.com", HttpTimeoutInSeconds = 5 });
             services.AddLogging();
             var sp = services.BuildServiceProvider();
@@ -164,8 +180,12 @@ namespace QRParserTest
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("OK") });
 
+            var httpClient = new HttpClient(handlerMock.Object);
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
             var services = new ServiceCollection();
-            services.AddTransient<HttpClient>((sp) => new HttpClient(handlerMock.Object));
+            services.AddSingleton(httpClientFactoryMock.Object);
             services.AddSingleton(new IsmpClientConfig { BaseUrlTobacco = "https://test.com", BaseUrlOther = "https://test.com", HttpTimeoutInSeconds = 5 });
             services.AddLogging();
             var sp = services.BuildServiceProvider();

--- a/src/tabalon.ismp.crpt/csp/TbkIsmpCrpt/IsmpRequest.cs
+++ b/src/tabalon.ismp.crpt/csp/TbkIsmpCrpt/IsmpRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
@@ -88,7 +89,8 @@ namespace TbkIsmpCrpt
             var httpMethod = _body == null ? HttpMethod.Get : HttpMethod.Post;
             using (var scope = _serviceProvider.CreateScope())
             {
-                var httpClient = scope.ServiceProvider.GetRequiredService<HttpClient>();
+                var httpClientFactory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+                var httpClient = httpClientFactory.CreateClient("IsmpClient");
 
                 var ismpClientConfig = scope.ServiceProvider.GetRequiredService<IsmpClientConfig>();
                 var urls = new[] { ismpClientConfig.BaseUrlTobacco, ismpClientConfig.BaseUrlOther };

--- a/src/tabalon.ismp.crpt/csp/TbkIsmpCrpt/TbkIsmpCrpt.csproj
+++ b/src/tabalon.ismp.crpt/csp/TbkIsmpCrpt/TbkIsmpCrpt.csproj
@@ -1,12 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
+ 	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
   </ItemGroup>

--- a/src/tabalon.ismp.crpt/csp/TbkIsmpCrptApi/Startup.cs
+++ b/src/tabalon.ismp.crpt/csp/TbkIsmpCrptApi/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -38,16 +39,14 @@ namespace TbkIsmpCrptApi
             services.AddSingleton<ISigner, BashFrameworkSigner>();
             services.AddSingleton<IIsmpClient, IsmpClient>();
 
-            services.AddTransient<HttpClient>((sp) =>
+            services.AddHttpClient("IsmpClient").ConfigureHttpClient((sp, client) =>
             {
                 var ismpClientConfig = sp.GetRequiredService<IsmpClientConfig>();
-                var httpClient = new HttpClient();
-                httpClient.BaseAddress = new Uri(ismpClientConfig.BaseUrlTobacco);
                 if (ismpClientConfig.HttpTimeoutInSeconds != 0)
                 {
-                    httpClient.Timeout = TimeSpan.FromSeconds(ismpClientConfig.HttpTimeoutInSeconds);
+                    client.Timeout = TimeSpan.FromSeconds(ismpClientConfig.HttpTimeoutInSeconds);
                 }
-                return httpClient;
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("TabakonIsmpClient/1.0");
             });
             services.AddSingleton<IMarkirovkaAuth, MarkirovkaAuth>();
             services.AddSingleton<IMarkirovkaClient, MarkirovkaClient>();

--- a/src/tabalon.ismp.crpt/csp/TbkIsmpCrptApi/TbkIsmpCrptApi.csproj
+++ b/src/tabalon.ismp.crpt/csp/TbkIsmpCrptApi/TbkIsmpCrptApi.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.10" />
-
+		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.10" />
 
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.*-*" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.*-*" />


### PR DESCRIPTION
﻿Добавлен User-Agent header "TabakonIsmpClient/1.0" для идентификации запросов. Использован IHttpClientFactory для лучшего управления жизненным циклом HttpClient. Обновлены unit-тесты для совместимости. Closes #13
