### PR TITLE
Отключение логов HttpClient

### DIFF
--- a/src/tabalon.ismp.crpt/csp/TbkIsmpCrptApi/appsettings.json
+++ b/src/tabalon.ismp.crpt/csp/TbkIsmpCrptApi/appsettings.json
@@ -7,17 +7,19 @@
 
   },
   "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    },
-    "Console": {
       "LogLevel": {
         "Default": "Information",
         "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System.Net.Http.HttpClient.IsmpClient.ClientHandler": "Warning"
       },
+      "Console": {
+        "LogLevel": {
+          "Default": "Information",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information",
+          "System.Net.Http.HttpClient.IsmpClient.ClientHandler": "Warning"
+        },
       "FormatterName": "CustomTimePrefixingFormatter",
       "FormatterOptions": {
         "CustomPrefix": "|-<[",


### PR DESCRIPTION
﻿Добавлен фильтр логирования для отключения info-логов от System.Net.Http.HttpClient.IsmpClient.ClientHandler в релизных сборках. Closes #13
