### PR TITLE
Исправление обработки GS1 строк в QRParser

### DIFF
--- a/src/tabalon.ismp.crpt/csp/QRParserTest/QrDataMatrixTests.cs
+++ b/src/tabalon.ismp.crpt/csp/QRParserTest/QrDataMatrixTests.cs
@@ -21,6 +21,7 @@ namespace QRParserTest
         [DataRow("0104610171993320215p1_;991EE1192X8V/aCSsDZi/lovrHG2WTCtGm/WWSmShyvA/9n5nSWE=", "0104610171993320215p1_;9")]
         [DataRow("0104610484027835215dm)oCPgCHOHf91EE1192fXOBGL899aDHWkarCAk4ZZZ5cyDdHcWsjxR7ewwr+dE=", "0104610484027835215dm)oCPgCHOHf")]
         [DataRow("0104610484027835215T7Y*RccvqX/G91EE1192nsBf/xd95nbABF2n0cDXOlK1Fh9+lZzgoUDZ5SF+dzo=", "0104610484027835215T7Y*RccvqX/G")]
+        [DataRow("010460165303918621GbEXjF?8005170000", "010460165303918621GbEXjF?")]
         public void GetCIS(string qr, string cis)
         {
             var qrPa = new QRParser(qr);

--- a/src/tabalon.ismp.crpt/csp/TbkIsmpCrptApi/QRParser.cs
+++ b/src/tabalon.ismp.crpt/csp/TbkIsmpCrptApi/QRParser.cs
@@ -131,6 +131,10 @@ namespace TbkIsmpCrptApi
 
                 if (dataLength > 0)
                 {
+                    if (pos + dataLength > gs1String.Length)
+                    {
+                        break;
+                    }
                     data = gs1String.Substring(pos, dataLength);
                     pos += dataLength;
                 }


### PR DESCRIPTION
## Краткое описание

Исправлена обработка неполных GS1 строк в QRParser, которая вызывала исключение `ArgumentOutOfRangeException` при парсинге QR-кодов с неполными данными AI (Application Identifier).

## Изменения

- **Добавлен тестовый случай**: Новый тест для QR-кода `010460165303918621GbEXjF?8005170000` с ожидаемым результатом `010460165303918621GbEXjF?`
- **Исправлена логика парсинга**: Добавлена проверка границ в методе `ParseGS1String` для предотвращения выхода за пределы строки
- **Обеспечена корректная обработка**: Теперь парсер корректно обрабатывает некорректные GS1 строки, усекая их на границах AI

## Технические детали

Проблема возникала при обработке GS1 строк, где данные для AI с фиксированной длиной были неполными. Метод пытался извлечь данные за пределами строки, что вызывало исключение. Добавлена проверка `if (pos + dataLength > gs1String.Length)` с досрочным выходом из цикла парсинга.

## Результат тестирования

Все существующие тесты продолжают проходить успешно. Новый тестовый случай также проходит, подтверждая корректность исправления.