### PR TITLE
Исправление ObjectDisposedException в тесте HTTP повторных запросов

### DIFF
--- a/src/tabalon.ismp.crpt/csp/QRParserTest/IsmpRequestTests.cs
+++ b/src/tabalon.ismp.crpt/csp/QRParserTest/IsmpRequestTests.cs
@@ -102,7 +102,7 @@ namespace QRParserTest
             var handlerMock = new Mock<HttpMessageHandler>();
             handlerMock.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Forbidden) { Content = new StringContent("Forbidden") });
+                .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.Forbidden) { Content = new StringContent("Forbidden") });
 
             var httpClient = new HttpClient(handlerMock.Object);
             var httpClientFactoryMock = new Mock<IHttpClientFactory>();


### PR DESCRIPTION
## Краткое описание

Исправлено падение теста `SendAsync_403Status_RetriesUpToTenTimes` из-за `ObjectDisposedException` при повторном использовании `StringContent` в HTTP запросах.

## Проблема

В тесте `SendAsync_403Status_RetriesUpToTenTimes` возникал `ObjectDisposedException`, так как один и тот же объект `StringContent` использовался многократно (20 раз) при повторных запросах. `StringContent` является disposable объектом и освобождался после первого использования, что приводило к исключению при последующих попытках.

## Решение

- **Изменен подход к созданию mock**: Вместо создания одного объекта `StringContent` используется lambda-выражение для создания нового экземпляра при каждом вызове
- **Предотвращено исключение**: Теперь каждый HTTP запрос получает новый `StringContent`, что исключает проблемы с освобожденными ресурсами

## Технические детали

Изменение в методе `Setup` mock'а:
```csharp
// Было:
.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Forbidden) { Content = new StringContent("Forbidden") });

// Стало:
.ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.Forbidden) { Content = new StringContent("Forbidden") });
```

## Результат тестирования

Все тесты теперь проходят успешно:
- Всего тестов: 19
- Успешных: 19
- Падающих: 0

Тест `SendAsync_403Status_RetriesUpToTenTimes` корректно проверяет 20 попыток (10 на каждый из 2 URL) без исключений.